### PR TITLE
Add LocalStack for AWS license requirement

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,7 @@ check:					  ## Check if all required prerequisites are available
 	@echo "All required prerequisites are available."
 
 start:					  ## Start localstack
+	@test -n "${LOCALSTACK_AUTH_TOKEN}" || (echo "LOCALSTACK_AUTH_TOKEN is not set. Find your token at https://app.localstack.cloud/workspace/auth-token"; exit 1)
 	$(LOCAL_ENV) LOCALSTACK_AUTH_TOKEN=$(LOCALSTACK_AUTH_TOKEN) docker compose up --build --detach --wait
 
 install: venv 		 	  ## Install dependencies	

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ The following diagram shows the architecture that this sample application builds
 
 ## Prerequisites
 
+- A valid [LocalStack for AWS license](https://localstack.cloud/pricing). Your license provides a `LOCALSTACK_AUTH_TOKEN` to activate LocalStack.
 - [`LOCALSTACK_AUTH_TOKEN`](https://docs.localstack.cloud/getting-started/auth-token/)
 - [Python 3.10+](https://www.python.org/downloads/) & `pip`
 - [Docker Compose](https://docs.docker.com/compose/install/) 
@@ -63,7 +64,7 @@ This will create a virtual environment and install the required Python packages 
 
 ## Deployment
 
-Start LocalStack Pro with the `LOCALSTACK_AUTH_TOKEN` pre-configured:
+Start LocalStack with the `LOCALSTACK_AUTH_TOKEN` pre-configured:
 
 ```shell
 export LOCALSTACK_AUTH_TOKEN=<your-auth-token>

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 | Categories   | Database Migration, Change Data Capture, Streaming                                       |
 | Level        | Intermediate                                                                             |
 | Use Case     | Database Migration, Real-time Data Replication, CDC Implementation                       |
-| GitHub       | [Repository link](https://github.com/localstack-samples/sample-dms-cdc-rds-to-kinesis)          |
+| GitHub       | [Repository link](https://github.com/localstack-samples/sample-dms-cdc-rds-to-kinesis)   |
 
 ## Introduction
 

--- a/README.md
+++ b/README.md
@@ -31,8 +31,7 @@ The following diagram shows the architecture that this sample application builds
 
 ## Prerequisites
 
-- A valid [LocalStack for AWS license](https://localstack.cloud/pricing). Your license provides a `LOCALSTACK_AUTH_TOKEN` to activate LocalStack.
-- [`LOCALSTACK_AUTH_TOKEN`](https://docs.localstack.cloud/getting-started/auth-token/)
+- A valid [LocalStack for AWS license](https://localstack.cloud/pricing). Your license provides a [`LOCALSTACK_AUTH_TOKEN`](https://docs.localstack.cloud/getting-started/auth-token/) to activate LocalStack.
 - [Python 3.10+](https://www.python.org/downloads/) & `pip`
 - [Docker Compose](https://docs.docker.com/compose/install/) 
 - [CDK](https://docs.localstack.cloud/user-guide/integrations/aws-cdk/) with the [`cdklocal`](https://github.com/localstack/aws-cdk-local) wrapper


### PR DESCRIPTION
Fixes [DEVREL-2](https://linear.app/localstack/issue/DEVREL-1/update-repositories-in-the-github-org-localstack-samples-such-that)

## Summary
- Add LocalStack for AWS license as first prerequisite with link to pricing page
- Clarify that a license provides the `LOCALSTACK_AUTH_TOKEN` needed to activate LocalStack
- Remove "LocalStack Pro" terminology from deployment instructions