### PR TITLE
Migrate sample to use `lstk`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,10 +32,14 @@ jobs:
         with:
           python-version: '3.11'
 
+      - name: Install lstk
+        run: |
+          npm install -g @localstack/lstk
+
       - name: Install CDK
         run: |
-          npm install -g aws-cdk-local aws-cdk
-          cdklocal --version
+          npm install -g aws-cdk
+          cdk --version
 
       - name: Install dependencies
         run: |

--- a/Makefile
+++ b/Makefile
@@ -37,10 +37,9 @@ venv: $(VENV_ACTIVATE)    ## Create a new (empty) virtual environment
 
 check:					  ## Check if all required prerequisites are available
 	@command -v docker > /dev/null 2>&1 || { echo "Docker is not installed."; exit 1; }
-	@command -v localstack > /dev/null 2>&1 || { echo "LocalStack is not installed."; exit 1; }
-	@command -v python > /dev/null 2>&1 || { echo "Python is not installed."; exit 1; }
+	@command -v python3 > /dev/null 2>&1 || { echo "Python 3 is not installed."; exit 1; }
 	@command -v cdk > /dev/null 2>&1 || { echo "AWS CDK is not installed."; exit 1; }
-	@command -v cdklocal > /dev/null 2>&1 || { echo "CDK Local is not installed."; exit 1; }
+	@command -v lstk > /dev/null 2>&1 || { echo "lstk is not installed."; exit 1; }
 	@echo "All required prerequisites are available."
 
 start:					  ## Start localstack
@@ -51,8 +50,8 @@ install: venv 		 	  ## Install dependencies
 	$(VENV_RUN); $(PIP_CMD) install -r requirements.txt
 
 deploy:					  ## Deploy the stack on LocalStack
-	$(VENV_RUN); $(LOCAL_ENV) cdklocal bootstrap --output ./cdk.local.out
-	$(VENV_RUN); $(LOCAL_ENV) cdklocal deploy --require-approval never --output ./cdk.local.out
+	$(VENV_RUN); $(LOCAL_ENV) lstk cdk bootstrap --output ./cdk.local.out
+	$(VENV_RUN); $(LOCAL_ENV) lstk cdk deploy --require-approval never --output ./cdk.local.out
 
 deploy-aws:				 ## Deploy the stack on AWS
 	$(VENV_RUN); $(CLOUD_ENV) cdk bootstrap

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The following diagram shows the architecture that this sample application builds
 - A valid [LocalStack for AWS license](https://localstack.cloud/pricing). Your license provides a [`LOCALSTACK_AUTH_TOKEN`](https://docs.localstack.cloud/getting-started/auth-token/) to activate LocalStack.
 - [Python 3.10+](https://www.python.org/downloads/) & `pip`
 - [Docker Compose](https://docs.docker.com/compose/install/) 
-- [CDK](https://docs.localstack.cloud/user-guide/integrations/aws-cdk/) with the [`cdklocal`](https://github.com/localstack/aws-cdk-local) wrapper
+- [CDK](https://docs.localstack.cloud/user-guide/integrations/aws-cdk/) with the [`lstk cdk` proxy](https://docs.localstack.cloud/aws/tooling/lstk/)
 - [`make`](https://www.gnu.org/software/make/) (**optional**, but recommended for running the sample application)
 
 ## Installation

--- a/dms_sample/stack.py
+++ b/dms_sample/stack.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import os
 from typing import Iterable


### PR DESCRIPTION
## Summary

- Use `lstk` instead of legacy `localstack`
- Replace cdklocal (aws-cdk-local) with the lstk CDK proxy across the Makefile, CI workflow, and README.
- Modernize the code base slightly, to remove test failures.

## Testing

- Manually executed the steps in `README.md`
- Manually invoked the CI workflows.
